### PR TITLE
Fix MySQL specific quoting and CONCAT()

### DIFF
--- a/block_quickfindlist.php
+++ b/block_quickfindlist.php
@@ -62,10 +62,10 @@ class block_quickfindlist extends block_base {
             $select = 'SELECT * ';
             $from = 'FROM {block} AS b
                         JOIN {block_instances} AS bi ON b.name = blockname ';
-            $where = 'WHERE name = "quickfindlist"
-                        AND pagetypepattern = "?"
+            $where = "WHERE name = 'quickfindlist'
+                        AND pagetypepattern = ?
                         AND parentcontextid = ?
-                        AND bi.id < ?';
+                        AND bi.id < ?";
             $params = array(
                 $this->instance->pagetypepattern,
                 $this->instance->parentcontextid,

--- a/edit_form.php
+++ b/edit_form.php
@@ -58,10 +58,10 @@ class block_quickfindlist_edit_form extends block_edit_form {
         $select = 'SELECT * ';
         $from = 'FROM {block} AS b
                     JOIN {block_instances} AS bi ON b.name = blockname ';
-        $where = 'WHERE name = "quickfindlist"
-                    AND pagetypepattern = "?"
+        $where = "WHERE name = 'quickfindlist'
+                    AND pagetypepattern = ?
                     AND parentcontextid = ?
-                    AND bi.id < ?';
+                    AND bi.id < ?";
         $params = array(
             $this->block->instance->pagetypepattern,
             $this->block->instance->parentcontextid,

--- a/quickfind.php
+++ b/quickfind.php
@@ -45,7 +45,7 @@ if (isloggedin() && has_capability('block/quickfindlist:use', $context) && confi
         $params = array("%$name%");
         $select = 'SELECT id, firstname, lastname, username ';
         $from = 'FROM {user} AS u ';
-        $where = "WHERE deleted = 0 AND CONCAT(firstname, ' ', lastname) LIKE ? ";
+        $where = "WHERE deleted = 0 AND " . $DB->sql_concat('firstname', 'lastname') . " LIKE ? ";
         if ($role != -1) {
             $params[] = $role;
             $subselect = 'SELECT COUNT(*) ';


### PR DESCRIPTION
This fixes some MySQL-specific and erroneous quoting, so it now runs on other RDMS systems such as Microsoft SQL Server.  More specifically:

Bound parameters are not quoted, as the binding handles that (uses ?, not "?").

String literals use single quotes, double quotes are for identifiers (MySQL accepts backticks for identifiers):
http://www.savage.net.au/SQL/sql-2003-2.bnf.html#character%20string%20literal

Use Moodle's $DB->sql_concat rather than MySQL-specific CONCAT()
