### PR TITLE
fixes get_context_instance() being deprecated

### DIFF
--- a/quickfind.php
+++ b/quickfind.php
@@ -34,7 +34,7 @@ $role = required_param('role', PARAM_INT);
 $courseformat = required_param('courseformat', PARAM_TEXT);
 $courseid = required_param('courseid', PARAM_TEXT);
 
-$context = get_context_instance(CONTEXT_COURSE, $courseid);
+$context = context_course::instance($courseid);
 
 if (isloggedin() && has_capability('block/quickfindlist:use', $context) && confirm_sesskey()) {
 


### PR DESCRIPTION
This is related to issue #24. Moodle has deprecated get_context_instance(). 